### PR TITLE
Fix stale season projections

### DIFF
--- a/R/projections.r
+++ b/R/projections.r
@@ -51,6 +51,7 @@ ffespn_projections <- function(season, week, pos = slot_names, scoring = c("ppr"
   # required different filters for season vs weekly projections
   if (week == 0) {
     players$filterStatsForExternalIds = list(value = season)
+    players$filterStatsForTopScoringPeriodIds = list(value = jsonlite::unbox(2), additionalValue = list( jsonlite::unbox(paste0("10", season)))) # Can get stale date w/o this
   } else {
     players$filterStatsForExternalIds = list(value = sprintf("%s%s", season, week))
   }


### PR DESCRIPTION
Can get stale week 0 projections w/o this filter.
E.g., compare ffespn_projections(2023, 0, "WR"), Tim Patrick (on IR), w/ and w/o this fix.